### PR TITLE
Check for existing vmoption before appending

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -141,7 +141,9 @@ if ! [ -z "${VMOPTIONS+x}" ]; then
 
     for vmoption in "${vmoptions[@]}"
     do
-        echo "${vmoption}" >> "$APP_DIR/oieserver.vmoptions"
+        if ! grep -Fqs -- "${vmoption}" "$APP_DIR/oieserver.vmoptions"; then
+            echo "${vmoption}" >> "$APP_DIR/oieserver.vmoptions"
+        fi
     done
 fi
 

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -141,7 +141,7 @@ if ! [ -z "${VMOPTIONS+x}" ]; then
 
     for vmoption in "${vmoptions[@]}"
     do
-        if ! grep -Fqs -- "${vmoption}" "$APP_DIR/oieserver.vmoptions"; then
+        if ! grep -Fqsx -- "${vmoption}" "$APP_DIR/oieserver.vmoptions"; then
             echo "${vmoption}" >> "$APP_DIR/oieserver.vmoptions"
         fi
     done


### PR DESCRIPTION
Prevent duplicate entries in `oieserver.vmoptions`. Current behavior will infinitely re-append all VMOPTIONS every time the container starts, even if VMOPTIONS has not changed.